### PR TITLE
add ReadTimeout functionality by merging upstream library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - 1.4
+  - 1.6
+  - tip
+env:
+  - GOOS=linux CGO=1
+  - GOOS=linux CGO=0
+  - GOOS=windows GOARCH=386

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func main() {
         }
         
         buf := make([]byte, 128)
-        n, err := s.Read(buf)
+        n, err = s.Read(buf)
         if err != nil {
                 log.Fatal(err)
         }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func main() {
         if err != nil {
                 log.Fatal(err)
         }
-        log.Print("%q", buf[:n])
+        log.Printf("%q", buf[:n])
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-GoSerial
+[![GoDoc](https://godoc.org/github.com/tarm/serial?status.svg)](http://godoc.org/github.com/tarm/serial)
+
+Serial
 ========
-A simple go package to allow you to read and write from the
+A Go package to allow you to read and write from the
 serial port as a stream of bytes.
 
 Details
 -------
 It aims to have the same API on all platforms, including windows.  As
 an added bonus, the windows package does not use cgo, so you can cross
-compile for windows from another platform.  Unfortunately goinstall
-does not currently let you cross compile so you will have to do it
-manually:
+compile for windows from another platform.
 
-    GOOS=windows make clean install
+You can cross compile with
+   GOOS=windows GOARCH=386 go install github.com/tarm/serial
 
 Currently there is very little in the way of configurability.  You can
 set the baud rate.  Then you can Read(), Write(), or Close() the
-connection.  Read() will block until at least one byte is returned.
-Write is the same.  There is currently no exposed way to set the
-timeouts, though patches are welcome.
+connection.  By default Read() will block until at least one byte is
+returned.  Write is the same.
 
 Currently all ports are opened with 8 data bits, 1 stop bit, no
 parity, no hardware flow control, and no software flow control.  This
@@ -33,8 +33,9 @@ Usage
 package main
 
 import (
-        "github.com/tarm/goserial"
         "log"
+
+        "github.com/tarm/serial"
 )
 
 func main() {
@@ -60,12 +61,12 @@ func main() {
 
 NonBlocking Mode
 ----------------
-By default goserial reads in blocking mode. Which means `Read()` will
-block until at least one byte is returned. If that's not what you want,
-specify a positive ReadTimeout and the Read() will timeout returning 0
-bytes if no bytes are read.
-Please note that this is the total timeout the read operation will wait
-and not the interval timeout between two bytes.
+By default the returned Port reads in blocking mode. Which means
+`Read()` will block until at least one byte is returned. If that's not
+what you want, specify a positive ReadTimeout and the Read() will
+timeout returning 0 bytes if no bytes are read.  Please note that this
+is the total timeout the read operation will wait and not the interval
+timeout between two bytes.
 
 ```go
 	c := &serial.Config{Name: "COM45", Baud: 115200, ReadTimeout: time.Second * 5}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![GoDoc](https://godoc.org/github.com/tarm/serial?status.svg)](http://godoc.org/github.com/tarm/serial)
+[![Build Status](https://travis-ci.org/tarm/serial.svg?branch=master)](https://travis-ci.org/tarm/serial)
 
 Serial
 ========

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ func main() {
 }
 ```
 
+NonBlocking Mode
+----------------
+	
+```go	
+	c := &serial.Config{Name: "COM45", Baud: 115200, NonBlockingRead: true, ReadTimeout: 1000}
+	// On Windows, ReadTimeout is in milliseconds (1000 = 1sec)
+	// where as on Linux and POSIX systems, ReadTimeout is in deciseconds (10 = 1sec)
+```
+
 Possible Future Work
 -------------------- 
 - better tests (loopback etc)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func main() {
         }
         
         buf := make([]byte, 128)
-        n, err = s.Read(buf)
+        n, err := s.Read(buf)
         if err != nil {
                 log.Fatal(err)
         }

--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ func main() {
 
 NonBlocking Mode
 ----------------
+By default goserial reads in blocking mode. Which means Read() will
+block until at least one byte is returned. If that's not what you want,
+specify a ReadTimeout in milliseconds and the Read() will timeout
+returning 0 bytes if no bytes are read.
+
+```go
+	c := &serial.Config{Name: "COM45", Baud: 115200, ReadTimeout: 1000}
 	
-```go	
-	c := &serial.Config{Name: "COM45", Baud: 115200, NonBlockingRead: true, ReadTimeout: 1000}
-	// On Windows, ReadTimeout is in milliseconds (1000 = 1sec)
-	// where as on Linux and POSIX systems, ReadTimeout is in deciseconds (10 = 1sec)
+	// In this mode, you will want to suppress error for read
+	// as 0 bytes returns EOF error on Linux / POSIX
+	n, _ = s.Read(buf)
 ```
 
 Possible Future Work

--- a/README.md
+++ b/README.md
@@ -60,16 +60,18 @@ func main() {
 
 NonBlocking Mode
 ----------------
-By default goserial reads in blocking mode. Which means Read() will
+By default goserial reads in blocking mode. Which means `Read()` will
 block until at least one byte is returned. If that's not what you want,
-specify a ReadTimeout in milliseconds and the Read() will timeout
-returning 0 bytes if no bytes are read.
+specify a positive ReadTimeout and the Read() will timeout returning 0
+bytes if no bytes are read.
+Please note that this is the total timeout the read operation will wait
+and not the interval timeout between two bytes.
 
 ```go
-	c := &serial.Config{Name: "COM45", Baud: 115200, ReadTimeout: 1000}
+	c := &serial.Config{Name: "COM45", Baud: 115200, ReadTimeout: time.Second * 5}
 	
 	// In this mode, you will want to suppress error for read
-	// as 0 bytes returns EOF error on Linux / POSIX
+	// as 0 bytes return EOF error on Linux / POSIX
 	n, _ = s.Read(buf)
 ```
 

--- a/basic_test.go
+++ b/basic_test.go
@@ -3,13 +3,19 @@
 package serial
 
 import (
+	"os"
 	"testing"
 	"time"
 )
 
 func TestConnection(t *testing.T) {
-	c0 := &Config{Name: "/dev/ttyUSB0", Baud: 115200}
-	c1 := &Config{Name: "/dev/ttyUSB1", Baud: 115200}
+	port0 := os.Getenv("PORT0")
+	port1 := os.Getenv("PORT1")
+	if port0 == "" || port1 == "" {
+		t.Skip("Skipping test because PORT0 or PORT1 environment variable is not set")
+	}
+	c0 := &Config{Name: port0, Baud: 115200}
+	c1 := &Config{Name: port1, Baud: 115200}
 
 	s1, err := OpenPort(c0)
 	if err != nil {

--- a/basic_test.go
+++ b/basic_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package serial
 
 import (

--- a/serial.go
+++ b/serial.go
@@ -56,7 +56,6 @@ Example usage:
 package serial
 
 import (
-	"io"
 	"time"
 )
 
@@ -92,7 +91,7 @@ type Config struct {
 }
 
 // OpenPort opens a serial port with the specified configuration
-func OpenPort(c *Config) (io.ReadWriteCloser, error) {
+func OpenPort(c *Config) (*Port, error) {
 	return openPort(c.Name, c.Baud, c.ReadTimeout)
 }
 

--- a/serial.go
+++ b/serial.go
@@ -65,11 +65,13 @@ import "io"
 //
 // For example:
 //
-//    c0 := &serial.Config{Name: "COM45", Baud: 115200}
+//    c0 := &serial.Config{Name: "COM45", Baud: 115200, NonBlockingRead: true, ReadTimeout: 1000}
 // or
 //    c1 := new(serial.Config)
 //    c1.Name = "/dev/tty.usbserial"
 //    c1.Baud = 115200
+//    c1.NonBlockingRead = true
+//    c1.ReadTimeout = 1000
 //
 type Config struct {
 	Name string
@@ -84,12 +86,13 @@ type Config struct {
 	// XONFlowControl bool
 
 	// CRLFTranslate bool
-	// TimeoutStuff int
+	NonBlockingRead bool
+	ReadTimeout     uint32
 }
 
 // OpenPort opens a serial port with the specified configuration
 func OpenPort(c *Config) (io.ReadWriteCloser, error) {
-	return openPort(c.Name, c.Baud)
+	return openPort(c.Name, c.Baud, c.NonBlockingRead, c.ReadTimeout)
 }
 
 // func Flush()

--- a/serial.go
+++ b/serial.go
@@ -65,12 +65,11 @@ import "io"
 //
 // For example:
 //
-//    c0 := &serial.Config{Name: "COM45", Baud: 115200, NonBlockingRead: true, ReadTimeout: 1000}
+//    c0 := &serial.Config{Name: "COM45", Baud: 115200, ReadTimeout: 1000}
 // or
 //    c1 := new(serial.Config)
 //    c1.Name = "/dev/tty.usbserial"
 //    c1.Baud = 115200
-//    c1.NonBlockingRead = true
 //    c1.ReadTimeout = 1000
 //
 type Config struct {
@@ -86,13 +85,12 @@ type Config struct {
 	// XONFlowControl bool
 
 	// CRLFTranslate bool
-	NonBlockingRead bool
-	ReadTimeout     uint32
+	ReadTimeout uint32
 }
 
 // OpenPort opens a serial port with the specified configuration
 func OpenPort(c *Config) (io.ReadWriteCloser, error) {
-	return openPort(c.Name, c.Baud, c.NonBlockingRead, c.ReadTimeout)
+	return openPort(c.Name, c.Baud, c.ReadTimeout)
 }
 
 // func Flush()

--- a/serial.go
+++ b/serial.go
@@ -29,7 +29,7 @@ Example usage:
   package main
 
   import (
-        "github.com/tarm/goserial"
+        "github.com/tarm/serial"
         "log"
   )
 

--- a/serial.go
+++ b/serial.go
@@ -118,8 +118,6 @@ func posixTimeoutValues(readTimeout time.Duration) (vmin uint8, vtime uint8) {
 	return minBytesToRead, uint8(readTimeoutInDeci)
 }
 
-// func Flush()
-
 // func SendBreak()
 
 // func RegisterBreakHandler(func())

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
+func openPort(name string, baud int, databits byte, parity Parity, stopbits StopBits, readTimeout time.Duration) (p *Port, err error) {
 	var bauds = map[int]uint32{
 		50:      syscall.B50,
 		75:      syscall.B75,
@@ -60,11 +60,47 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		}
 	}()
 
+	// Base settings
+	cflagToUse := syscall.CREAD | syscall.CLOCAL | rate
+	switch databits {
+	case 5:
+		cflagToUse |= syscall.CS5
+	case 6:
+		cflagToUse |= syscall.CS6
+	case 7:
+		cflagToUse |= syscall.CS7
+	case 8:
+		cflagToUse |= syscall.CS8
+	default:
+		return nil, ErrBadSize
+	}
+	// Stop bits settings
+	switch stopbits {
+	case Stop1:
+		// default is 1 stop bit
+	case Stop2:
+		cflagToUse |= syscall.CSTOPB
+	default:
+		// Don't know how to set 1.5
+		return nil, ErrBadStopBits
+	}
+	// Parity settings
+	switch parity {
+	case ParityNone:
+		// default is no parity
+	case ParityOdd:
+		cflagToUse |= syscall.PARENB
+		cflagToUse |= syscall.PARODD
+	case ParityEven:
+		cflagToUse |= syscall.PARENB
+	default:
+		return nil, ErrBadParity
+	}
 	fd := f.Fd()
 	vmin, vtime := posixTimeoutValues(readTimeout)
 	t := syscall.Termios{
 		Iflag:  syscall.IGNPAR,
-		Cflag:  syscall.CS8 | syscall.CREAD | syscall.CLOCAL | rate,
+		Cflag:  cflagToUse,
 		Cc:     [32]uint8{syscall.VMIN: vmin, syscall.VTIME: vtime},
 		Ispeed: rate,
 		Ospeed: rate,

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -103,6 +103,8 @@ func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
 }
 
+// Discards data written to the port but not transmitted,
+// or data received but not read
 func (p *Port) Flush() error {
 	const TCFLSH = 0x540B
 	_, _, err := syscall.Syscall(

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -3,15 +3,13 @@
 package serial
 
 import (
-	"io"
 	"os"
 	"syscall"
 	"time"
 	"unsafe"
 )
 
-func openPort(name string, baud int, readTimeout time.Duration) (rwc io.ReadWriteCloser, err error) {
-
+func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
 	var bauds = map[int]uint32{
 		50:      syscall.B50,
 		75:      syscall.B75,
@@ -88,5 +86,23 @@ func openPort(name string, baud int, readTimeout time.Duration) (rwc io.ReadWrit
 		return
 	}
 
-	return f, nil
+	return &Port{f: f}, nil
+}
+
+type Port struct {
+	// We intentionly do not use an "embedded" struct so that we
+	// don't export File
+	f *os.File
+}
+
+func (p *Port) Read(b []byte) (n int, err error) {
+	return p.f.Read(b)
+}
+
+func (p *Port) Write(b []byte) (n int, err error) {
+	return p.f.Write(b)
+}
+
+func (p *Port) Close() (err error) {
+	return p.f.Close()
 }

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -86,13 +86,14 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		return
 	}
 
-	return &Port{f: f}, nil
+	return &Port{f: f, fd: fd}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f *os.File
+	f  *os.File
+	fd uintptr
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -101,6 +102,17 @@ func (p *Port) Read(b []byte) (n int, err error) {
 
 func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
+}
+
+func (p *Port) Flush() error {
+	const TCFLSH = 0x540B
+	_, _, err := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(p.fd),
+		uintptr(TCFLSH),
+		uintptr(syscall.TCIOFLUSH),
+	)
+	return err
 }
 
 func (p *Port) Close() (err error) {

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -86,14 +86,13 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		return
 	}
 
-	return &Port{f: f, fd: fd}, nil
+	return &Port{f: f}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f  *os.File
-	fd uintptr
+	f *os.File
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -108,7 +107,7 @@ func (p *Port) Flush() error {
 	const TCFLSH = 0x540B
 	_, _, err := syscall.Syscall(
 		syscall.SYS_IOCTL,
-		uintptr(p.fd),
+		uintptr(p.f.Fd()),
 		uintptr(TCFLSH),
 		uintptr(syscall.TCIOFLUSH),
 	)

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -11,14 +11,13 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"syscall"
 	"time"
 	//"unsafe"
 )
 
-func openPort(name string, baud int, readTimeout time.Duration) (rwc io.ReadWriteCloser, err error) {
+func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
 	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
 	if err != nil {
 		return
@@ -117,5 +116,23 @@ func openPort(name string, baud int, readTimeout time.Duration) (rwc io.ReadWrit
 				}
 	*/
 
-	return f, nil
+	return &Port{f: f}, nil
+}
+
+type Port struct {
+	// We intentionly do not use an "embedded" struct so that we
+	// don't export File
+	f *os.File
+}
+
+func (p *Port) Read(b []byte) (n int, err error) {
+	return p.f.Read(b)
+}
+
+func (p *Port) Write(b []byte) (n int, err error) {
+	return p.f.Write(b)
+}
+
+func (p *Port) Close() (err error) {
+	return p.f.Close()
 }

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -116,14 +116,13 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 				}
 	*/
 
-	return &Port{f: f, fd: fd}, nil
+	return &Port{f: f}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f  *os.File
-	fd C.int
+	f *os.File
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -135,7 +134,7 @@ func (p *Port) Write(b []byte) (n int, err error) {
 }
 
 func (p *Port) Flush() error {
-	_, err := C.tcflush(p.fd, C.TCIOFLUSH)
+	_, err := C.tcflush(C.int(p.f.Fd()), C.TCIOFLUSH)
 	return err
 }
 

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -116,13 +116,14 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 				}
 	*/
 
-	return &Port{f: f}, nil
+	return &Port{f: f, fd: fd}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f *os.File
+	f  *os.File
+	fd C.int
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -131,6 +132,11 @@ func (p *Port) Read(b []byte) (n int, err error) {
 
 func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
+}
+
+func (p *Port) Flush() error {
+	_, err := C.tcflush(p.fd, C.TCIOFLUSH)
+	return err
 }
 
 func (p *Port) Close() (err error) {

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -133,6 +133,8 @@ func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
 }
 
+// Discards data written to the port but not transmitted,
+// or data received but not read
 func (p *Port) Flush() error {
 	_, err := C.tcflush(C.int(p.f.Fd()), C.TCIOFLUSH)
 	return err

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -51,6 +51,24 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 		speed = C.B4800
 	case 2400:
 		speed = C.B2400
+	case 1200:
+		speed = C.B1200
+	case 600:
+		speed = C.B600
+	case 300:
+		speed = C.B300
+	case 200:
+		speed = C.B200
+	case 150:
+		speed = C.B150
+	case 134:
+		speed = C.B134
+	case 110:
+		speed = C.B110
+	case 75:
+		speed = C.B75
+	case 50:
+		speed = C.B50
 	default:
 		f.Close()
 		return nil, fmt.Errorf("Unknown baud rate %v", baud)

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -127,6 +127,8 @@ func (p *Port) Read(buf []byte) (int, error) {
 	return getOverlappedResult(p.fd, p.ro)
 }
 
+// Discards data written to the port but not transmitted,
+// or data received but not read
 func (p *Port) Flush() error {
 	return purgeComm(p.fd)
 }

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -37,7 +37,7 @@ type structTimeouts struct {
 	WriteTotalTimeoutConstant   uint32
 }
 
-func openPort(name string, baud int, nonBlockingRead bool, readTimeout uint32) (rwc io.ReadWriteCloser, err error) {
+func openPort(name string, baud int, readTimeout uint32) (rwc io.ReadWriteCloser, err error) {
 	if len(name) > 0 && name[0] != '\\' {
 		name = "\\\\.\\" + name
 	}
@@ -65,7 +65,7 @@ func openPort(name string, baud int, nonBlockingRead bool, readTimeout uint32) (
 	if err = setupComm(h, 64, 64); err != nil {
 		return
 	}
-	if err = setCommTimeouts(h, nonBlockingRead, readTimeout); err != nil {
+	if err = setCommTimeouts(h, readTimeout); err != nil {
 		return
 	}
 	if err = setCommMask(h); err != nil {
@@ -178,18 +178,20 @@ func setCommState(h syscall.Handle, baud int) error {
 	return nil
 }
 
-func setCommTimeouts(h syscall.Handle, nonBlockingRead bool, readTimeout uint32) error {
+func setCommTimeouts(h syscall.Handle, readTimeout uint32) error {
 	var timeouts structTimeouts
 	const MAXDWORD = 1<<32 - 1
-	if nonBlockingRead == true {
+	if readTimeout > 0 {
+		// non-blocking read
 		timeouts.ReadIntervalTimeout = 1000
 		timeouts.ReadTotalTimeoutMultiplier = 0
 		timeouts.ReadTotalTimeoutConstant = readTimeout
 	} else {
+		// blocking read
 		timeouts.ReadIntervalTimeout = MAXDWORD
 		timeouts.ReadTotalTimeoutMultiplier = MAXDWORD
 		timeouts.ReadTotalTimeoutConstant = MAXDWORD - 1
-	}	
+	}
 
 	/* From http://msdn.microsoft.com/en-us/library/aa363190(v=VS.85).aspx
 

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -127,6 +127,10 @@ func (p *Port) Read(buf []byte) (int, error) {
 	return getOverlappedResult(p.fd, p.ro)
 }
 
+func (p *Port) Flush() error {
+	return purgeComm(p.fd)
+}
+
 var (
 	nSetCommState,
 	nSetCommTimeouts,
@@ -134,7 +138,9 @@ var (
 	nSetupComm,
 	nGetOverlappedResult,
 	nCreateEvent,
-	nResetEvent uintptr
+	nResetEvent,
+	nPurgeComm,
+	nFlushFileBuffers uintptr
 )
 
 func init() {
@@ -151,6 +157,8 @@ func init() {
 	nGetOverlappedResult = getProcAddr(k32, "GetOverlappedResult")
 	nCreateEvent = getProcAddr(k32, "CreateEventW")
 	nResetEvent = getProcAddr(k32, "ResetEvent")
+	nPurgeComm = getProcAddr(k32, "PurgeComm")
+	nFlushFileBuffers = getProcAddr(k32, "FlushFileBuffers")
 }
 
 func getProcAddr(lib syscall.Handle, name string) uintptr {
@@ -248,6 +256,19 @@ func setCommMask(h syscall.Handle) error {
 
 func resetEvent(h syscall.Handle) error {
 	r, _, err := syscall.Syscall(nResetEvent, 1, uintptr(h), 0, 0)
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func purgeComm(h syscall.Handle) error {
+	const PURGE_TXABORT = 0x0001
+	const PURGE_RXABORT = 0x0002
+	const PURGE_TXCLEAR = 0x0004
+	const PURGE_RXCLEAR = 0x0008
+	r, _, err := syscall.Syscall(nPurgeComm, 2, uintptr(h),
+		PURGE_TXABORT|PURGE_RXABORT|PURGE_TXCLEAR|PURGE_RXCLEAR, 0)
 	if r == 0 {
 		return err
 	}

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -60,25 +60,25 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	}()
 
 	if err = setCommState(h, baud, databits, parity, stopbits); err != nil {
-		return
+		return nil, err
 	}
 	if err = setupComm(h, 64, 64); err != nil {
-		return
+		return nil, err
 	}
 	if err = setCommTimeouts(h, readTimeout); err != nil {
-		return
+		return nil, err
 	}
 	if err = setCommMask(h); err != nil {
-		return
+		return nil, err
 	}
 
 	ro, err := newOverlapped()
 	if err != nil {
-		return
+		return nil, err
 	}
 	wo, err := newOverlapped()
 	if err != nil {
-		return
+		return nil, err
 	}
 	port := new(Port)
 	port.f = f

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -193,7 +193,7 @@ func setCommTimeouts(h syscall.Handle, readTimeout time.Duration) error {
 	const MAXDWORD = 1<<32 - 1
 
 	// blocking read by default
-	var timeoutMs int64 = MAXDWORD
+	var timeoutMs int64 = MAXDWORD - 1
 
 	if readTimeout > 0 {
 		// non-blocking read

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -182,13 +182,18 @@ func setCommState(h syscall.Handle, baud int) error {
 func setCommTimeouts(h syscall.Handle, readTimeout time.Duration) error {
 	var timeouts structTimeouts
 	const MAXDWORD = 1<<32 - 1
-	timeoutMs := uint32(readTimeout.Nanoseconds() / 1e6)
 
-	if timeoutMs > 0 {
+	if readTimeout > 0 {
 		// non-blocking read
+		timeoutMs := readTimeout.Nanoseconds() / 1e6
+		if timeoutMs < 1 {
+			timeoutMs = 1
+		} else if timeoutMs > MAXDWORD {
+			timeoutMs = MAXDWORD
+		}
 		timeouts.ReadIntervalTimeout = 0
 		timeouts.ReadTotalTimeoutMultiplier = 0
-		timeouts.ReadTotalTimeoutConstant = timeoutMs
+		timeouts.ReadTotalTimeoutConstant = uint32(timeoutMs)
 	} else {
 		// blocking read
 		timeouts.ReadIntervalTimeout = MAXDWORD

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -197,7 +197,7 @@ func setCommTimeouts(h syscall.Handle, readTimeout time.Duration) error {
 
 	if readTimeout > 0 {
 		// non-blocking read
-		timeoutMs := readTimeout.Nanoseconds() / 1e6
+		timeoutMs = readTimeout.Nanoseconds() / 1e6
 		if timeoutMs < 1 {
 			timeoutMs = 1
 		} else if timeoutMs > MAXDWORD-1 {


### PR DESCRIPTION
Merge the code from upstream (tarm/serial), to bring the ReadTimeout feature.

Unfortunately, the merge is non-trivial, because of the changes present in our fork (zpas-lab/serial).