### PR TITLE
serial_posix: fix even parity

### DIFF
--- a/serial_posix.go
+++ b/serial_posix.go
@@ -142,6 +142,7 @@ func openPort(c *Config) (p *Port, err error) {
 		st.c_cflag |= C.PARODD
 	case ParityEven:
 		st.c_cflag |= C.PARENB
+		st.c_cflag &= ^C.tcflag_t(C.PARODD)
 	default:
 		return nil, ErrBadParity
 	}


### PR DESCRIPTION
Previously, when even parity was requested, PARODD was erroneously
retained, and thus could actually result in odd parity being set
(as loaded earlier by tcgetattr).